### PR TITLE
优化选择多个城市时首页的滑动流畅度

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+PlayWeather


### PR DESCRIPTION
将页面中的Effect单独提取出来，避免pagerState.currentPage改变时导致整个ViewPager重组